### PR TITLE
add XML parser's option for short application name

### DIFF
--- a/src/ios/after_prepare_hook.js
+++ b/src/ios/after_prepare_hook.js
@@ -28,7 +28,7 @@ module.exports = function(context) {
     fs.writeFileSync(PATH, '#define CDVREPRO_ENABLE_SWIZZLING ' + value);
   }
 
-  var parser = new xml2js.Parser();
+  var parser = new xml2js.Parser({ignoreAttrs: true});
   var CONFIG_XML_PATH = path.join(context.opts.projectRoot, 'config.xml');
   var config = fs.readFileSync(CONFIG_XML_PATH, 'utf8');
 


### PR DESCRIPTION
I can't swizzle, when I use short application name attribution.
```
EX.
<name short="アプリ名">ApplicationName</name>
```