### PR TITLE
Update repro-android-sdk.gradle

### DIFF
--- a/src/android/repro-android-sdk.gradle
+++ b/src/android/repro-android-sdk.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
 


### PR DESCRIPTION
Android build failed due to failure to obtain maven-metadata.xml.
Consider migrating to MavenCentral since JCenter has already been terminated.

```
Consider migrating to MavenCentral since JCenter has already been terminated.* What went wrong:
A problem occurred evaluating project ':app'.
> Could not resolve all artifacts for configuration 'classpath'.
   > Could not resolve io.grpc:grpc-api:[1.39.0].
     Required by:
         unspecified:unspecified:unspecified > com.android.tools.build:gradle:7.4.0-alpha02 > io.grpc:grpc-core:1.39.0
      > Failed to list versions for io.grpc:grpc-api.
         > Unable to load Maven meta-data from https://jcenter.bintray.com/io/grpc/grpc-api/maven-metadata.xml.
            > Could not HEAD 'https://jcenter.bintray.com/io/grpc/grpc-api/maven-metadata.xml'.
               > org.apache.http.client.ClientProtocolException (no error message)
```